### PR TITLE
Fix tvOS Build

### DIFF
--- a/Sources/JavaScriptCoreExtras/JSValue+Utils.swift
+++ b/Sources/JavaScriptCoreExtras/JSValue+Utils.swift
@@ -1,7 +1,29 @@
 import JavaScriptCore
 
 extension JSValue {
+  /// Whether or not this value is iterable.
   public var isIterable: Bool {
-    self.hasProperty(self.context.evaluateScript("Symbol.iterator"))
+    #if !os(tvOS)
+      self.hasProperty(self.context.evaluateScript("Symbol.iterator"))
+    #else
+      var obj = self.context.objectForKeyedSubscript("_jsCoreExtrasIsIterable")
+      if obj == nil || obj?.isUndefined == true {
+        self.context.installIsIterable()
+        obj = self.context.objectForKeyedSubscript("_jsCoreExtrasIsIterable")
+      }
+      return obj?.call(withArguments: [self]).toBool() ?? false
+    #endif
+  }
+}
+
+extension JSContext {
+  fileprivate func installIsIterable() {
+    self.evaluateScript(
+      """
+      function _jsCoreExtrasIsIterable(obj) {
+        return !!obj[Symbol.iterator];
+      }
+      """
+    )
   }
 }


### PR DESCRIPTION
`hasProperty` only works with strings on tvOS, so update `JSValue.isIterable` to use a JS function in the context instead of using `hasProperty`.