### PR TITLE
Fix race condition where executor was returned before being initialized

### DIFF
--- a/Sources/JavaScriptCoreExtras/Concurrency/JSGlobalActor.swift
+++ b/Sources/JavaScriptCoreExtras/Concurrency/JSGlobalActor.swift
@@ -84,15 +84,16 @@ public final actor JSGlobalActor {
 extension JSVirtualMachineExecutor {
   fileprivate func blockUntilStartsRunning() {
     let condition = NSCondition()
-    condition.lock()
 
     Thread.detachNewThread { [weak self] in
-      condition.lock()
-      condition.signal()
-      condition.unlock()
-      self?.runBlocking()
+      self?.runBlocking {
+        condition.lock()
+        condition.signal()
+        condition.unlock()
+      }
     }
 
+    condition.lock()
     condition.wait()
     condition.unlock()
   }

--- a/Sources/JavaScriptCoreExtras/Concurrency/JSVirtualMachineExecutor.swift
+++ b/Sources/JavaScriptCoreExtras/Concurrency/JSVirtualMachineExecutor.swift
@@ -94,12 +94,13 @@ extension JSVirtualMachineExecutor {
   ///
   /// > Warning: This will indefinitely block the current thread of execution until ``stop()`` is
   /// > explicitly called. Use ``run()`` if you do not want to block the current thread.
-  public func runBlocking() {
+  public func runBlocking(onStart: (@Sendable () -> Void)? = nil) {
     self.runner.withLock {
       $0 = Runner()
       Self.threadLocal = WeakBox(value: self)
       JSVirtualMachine.threadLocal = self.createVirtualMachine()
     }
+    onStart?()
     CFRunLoopRun()
   }
 

--- a/Sources/JavaScriptCoreExtras/Concurrency/JSVirtualMachineExecutorPool.swift
+++ b/Sources/JavaScriptCoreExtras/Concurrency/JSVirtualMachineExecutorPool.swift
@@ -93,20 +93,20 @@ extension JSVirtualMachineExecutorPool {
         } else {
           self.isCreatingMachineCondition = true
           Thread.detachNewThread {
-            self.condition.lock()
-            let executor = self.state.withLock { state in
-              let executor = JSVirtualMachineExecutor(
-                createVirtualMachine: self.createVirtualMachine
-              )
-              state.cells[state.index] = ExecutorCell(referenceCount: 1, executor: executor)
-              state.index = self.nextCellIndex(in: state)
-              return executor
+            let executor = JSVirtualMachineExecutor(
+              createVirtualMachine: self.createVirtualMachine
+            )
+            executor.runBlocking {
+              self.condition.lock()
+              self.state.withLock { state in
+                state.cells[state.index] = ExecutorCell(referenceCount: 1, executor: executor)
+                state.index = self.nextCellIndex(in: state)
+              }
+              continuation.resume(returning: executor)
+              self.isCreatingMachineCondition = false
+              self.condition.signal()
+              self.condition.unlock()
             }
-            continuation.resume(returning: executor)
-            self.isCreatingMachineCondition = false
-            self.condition.signal()
-            self.condition.unlock()
-            executor.runBlocking()
           }
         }
       }


### PR DESCRIPTION
## Problem

`JSVirtualMachineExecutorPool.executor()` and `JSGlobalActor.blockUntilStartsRunning()` both had a race condition where they signaled readiness **before** the executor was actually initialized.

In the pool, the continuation was resumed before `runBlocking()` created the Runner, meaning the caller received an executor whose `isRunning` was `false` and `enqueue` would fail. In the actor, the condition was signaled before the Runner existed, so `blockUntilStartsRunning()` could return before the executor was ready.

## Fix

Add an `onStart` callback parameter to `runBlocking()` that fires after the Runner and thread-local state are set up but before `CFRunLoopRun()` blocks. Both call sites now signal/resume inside this callback, guaranteeing the executor is running before callers proceed.

`runBlocking(onStart:)` defaults to `nil`, so all existing call sites (including `run()`) continue to work without modification.