### PR TITLE
Dispatch continuation.resume back to executor thread in fetch and blob

### DIFF
--- a/Sources/JavaScriptCoreExtras/Blob/JSBlob.swift
+++ b/Sources/JavaScriptCoreExtras/Blob/JSBlob.swift
@@ -156,8 +156,9 @@ extension JSBlob: JSBlobExport {
     _ map: @Sendable @escaping (String.UTF8View, JSContext) -> Any?
   ) -> JSPromise {
     JSPromise(in: .current()) { continuation in
+      let executor = JSVirtualMachineExecutor.current()
       let indexedStorage = self.indexedStorage
-      Task { await indexedStorage.utf8(continuation: continuation, map) }
+      Task { await indexedStorage.utf8(continuation: continuation, executor: executor, map) }
     }
   }
 }
@@ -180,14 +181,27 @@ extension JSBlob {
 
     func utf8(
       continuation: JSPromise.Continuation,
+      executor: JSVirtualMachineExecutor?,
       _ map: (String.UTF8View, JSContext) -> Any?
     ) async {
       do {
-        continuation.resume(
-          resolving: map(try await self.utf8(context: continuation.context), continuation.context)
-        )
+        let result = map(try await self.utf8(context: continuation.context), continuation.context)
+        if let executor {
+          nonisolated(unsafe) let capturedResult = result
+          await executor.withVirtualMachine { _ in
+            continuation.resume(resolving: capturedResult)
+          }
+        } else {
+          continuation.resume(resolving: result)
+        }
       } catch {
-        continuation.resume(rejecting: error.value)
+        if let executor {
+          await executor.withVirtualMachine { _ in
+            continuation.resume(rejecting: error.value)
+          }
+        } else {
+          continuation.resume(rejecting: error.value)
+        }
       }
     }
   }

--- a/Sources/JavaScriptCoreExtras/Fetch/JSFetch.swift
+++ b/Sources/JavaScriptCoreExtras/Fetch/JSFetch.swift
@@ -99,10 +99,11 @@ extension JSContextInstallable where Self == JSFetchInstaller {
 extension JSFetchTask: JSFetchTaskExport {
   func perform() -> JSValue {
     JSPromise(in: .current()) { continuation in
+      let executor = JSVirtualMachineExecutor.current()
       self.state.withLock { state in
         let task = state.task ?? self.session.dataTask(with: self.request)
         state.task = task
-        state.delegate.addFetchContinuation(continuation, for: task.taskIdentifier)
+        state.delegate.addFetchContinuation(continuation, executor: executor, for: task.taskIdentifier)
         guard !state.delegate.rejectIfCancelled(for: task.taskIdentifier) else { return }
         if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *), !state.delegate.isShared {
           task.delegate = state.delegate
@@ -135,6 +136,7 @@ private final class JSURLSessionDataDelegate: NSObject {
     var didRedirect = false
     var continuation: JSPromise.Continuation?
     var response: HTTPURLResponse?
+    var executor: JSVirtualMachineExecutor?
   }
 
   let isShared: Bool
@@ -146,8 +148,15 @@ private final class JSURLSessionDataDelegate: NSObject {
 }
 
 extension JSURLSessionDataDelegate {
-  func addFetchContinuation(_ continuation: JSPromise.Continuation, for taskId: TaskID) {
-    self.editState(for: taskId) { $0.continuation = continuation }
+  func addFetchContinuation(
+    _ continuation: JSPromise.Continuation,
+    executor: JSVirtualMachineExecutor?,
+    for taskId: TaskID
+  ) {
+    self.editState(for: taskId) {
+      $0.continuation = continuation
+      $0.executor = executor
+    }
   }
 
   func markCancelReason(reason: UnsafeJSValueTransfer, for taskId: TaskID) {
@@ -175,12 +184,25 @@ extension JSURLSessionDataDelegate: URLSessionDataDelegate {
     self.editState(for: dataTask.taskIdentifier) { state in
       guard let continuation = state.continuation else { return }
       guard let response = response as? HTTPURLResponse else {
-        continuation.resume(
-          rejecting: JSValue(
-            newErrorFromMessage: "Server responded with a non-HTTP response.",
-            in: continuation.context
+        if let executor = state.executor {
+          Task {
+            await executor.withVirtualMachine { _ in
+              continuation.resume(
+                rejecting: JSValue(
+                  newErrorFromMessage: "Server responded with a non-HTTP response.",
+                  in: continuation.context
+                )
+              )
+            }
+          }
+        } else {
+          continuation.resume(
+            rejecting: JSValue(
+              newErrorFromMessage: "Server responded with a non-HTTP response.",
+              in: continuation.context
+            )
           )
-        )
+        }
         return
       }
       let (cookies, _) = response.cookieFilteredHeaders
@@ -233,17 +255,32 @@ extension JSURLSessionDataDelegate: URLSessionDataDelegate {
 
   private func resolveError(in state: inout State, error: any Error) {
     guard let continuation = state.continuation else { return }
-    if let error = error as? URLError, error.code == .cancelled {
-      continuation.resume(rejecting: state.cancelReason)
-    } else {
-      continuation.resume(
-        rejecting: JSValue(
-          newErrorFromMessage: error.localizedDescription,
-          in: continuation.context
-        )
-      )
-    }
+    let executor = state.executor
+    let cancelReason = state.cancelReason
+    let isCancelled = (error as? URLError)?.code == .cancelled
+    let errorMessage = error.localizedDescription
     state.didResolveResponse = true
+    if let executor {
+      Task {
+        await executor.withVirtualMachine { _ in
+          if isCancelled {
+            continuation.resume(rejecting: cancelReason)
+          } else {
+            continuation.resume(
+              rejecting: JSValue(newErrorFromMessage: errorMessage, in: continuation.context)
+            )
+          }
+        }
+      }
+    } else {
+      if isCancelled {
+        continuation.resume(rejecting: cancelReason)
+      } else {
+        continuation.resume(
+          rejecting: JSValue(newErrorFromMessage: errorMessage, in: continuation.context)
+        )
+      }
+    }
   }
 
   private func resolveResponse(task: URLSessionTask) async {
@@ -264,16 +301,36 @@ extension JSURLSessionDataDelegate: URLSessionDataDelegate {
   ) {
     guard let response = state.response, let continuation = state.continuation else { return }
     let (_, headers) = response.cookieFilteredHeaders
-    continuation.resume(
-      resolving: JSValue.response(
-        response: response,
-        headers: headers,
-        body: storage,
-        didRedirect: state.didRedirect,
-        in: continuation.context
-      )
-    )
+    let didRedirect = state.didRedirect
+    let executor = state.executor
     state.didResolveResponse = true
+    nonisolated(unsafe) let capturedHeaders = headers
+    nonisolated(unsafe) let capturedStorage = storage
+    if let executor {
+      Task {
+        await executor.withVirtualMachine { _ in
+          continuation.resume(
+            resolving: JSValue.response(
+              response: response,
+              headers: capturedHeaders,
+              body: capturedStorage,
+              didRedirect: didRedirect,
+              in: continuation.context
+            )
+          )
+        }
+      }
+    } else {
+      continuation.resume(
+        resolving: JSValue.response(
+          response: response,
+          headers: capturedHeaders,
+          body: capturedStorage,
+          didRedirect: didRedirect,
+          in: continuation.context
+        )
+      )
+    }
   }
 }
 

--- a/Tests/JavaScriptCoreExtrasTests/BlobTests/JSBlobTests.swift
+++ b/Tests/JavaScriptCoreExtrasTests/BlobTests/JSBlobTests.swift
@@ -150,4 +150,31 @@ struct JSBlobTests {
       expectNoDifference(Set(values), ["foobar", "oob", "oobar", "test", "", "o"])
     }
   }
+
+  #if swift(>=6.2)
+    @Test("Resolves Async Function After Blob Text Without Executor Crash")
+    func asyncFunctionAfterBlobTextDoesNotCrash() async throws {
+      try await withContextActor { contextActor in
+        let context = contextActor.value
+        try context.install([.blob])
+        context.setAsyncFunction(forKey: "addOne", Int.self) { _, i in
+          i + 1
+        }
+        let promise = context
+          .evaluateScript(
+            """
+            const run = async () => {
+              const blob = new Blob(["hello"])
+              await blob.text()
+              return addOne(41)
+            }
+            run()
+            """
+          )!
+        let promiseValue = try JSPromiseValue<Int>(jsValue: promise)
+        let value = try await promiseValue.resolvedValue()
+        expectNoDifference(value, 42)
+      }
+    }
+  #endif
 }

--- a/Tests/JavaScriptCoreExtrasTests/FetchTests/JSFetchTests.swift
+++ b/Tests/JavaScriptCoreExtrasTests/FetchTests/JSFetchTests.swift
@@ -701,6 +701,35 @@ struct JSFetchTests: @unchecked Sendable {
     expectNoDifference(value?.toString(), "hello world")
   }
 
+  @Test("Resolves Async Function After Fetch Without Executor Crash")
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+  func asyncFunctionAfterFetchDoesNotCrash() async throws {
+    try await withTestURLSessionHandler { _ in
+      return (200, .data(Data("ok".utf8)))
+    } perform: { session in
+      try await withContextActor { contextActor in
+        let context = contextActor.value
+        try context.install([.fetch(session: session)])
+        context.setAsyncFunction(forKey: "addOne", Int.self) { _, i in
+          i + 1
+        }
+        let promise = context
+          .evaluateScript(
+            """
+            const run = async () => {
+              const resp = await fetch("https://www.example.com")
+              return addOne(41)
+            }
+            run()
+            """
+          )!
+        let promiseValue = try JSPromiseValue<Int>(jsValue: promise)
+        let value = try await promiseValue.resolvedValue()
+        expectNoDifference(value, 42)
+      }
+    }
+  }
+
   @Test("Live Fetches a Large Data Payload")
   func liveFetchLarge() async throws {
     try self.context.install([.fetch])


### PR DESCRIPTION
When a fetch or blob Promise resolves, the `continuation.resume` call was running on URLSession's delegate queue or a cooperative `Task` thread — not on the `JSVirtualMachineExecutor`'s dedicated thread. This caused JSC to drain microtasks on the wrong thread, crashing when `setAsyncFunction` callbacks tried to construct `JSPromiseValue` without a running executor.

**Fix:** Capture the executor at Promise creation time (when we're still on the executor thread) and store it alongside the continuation. Then dispatch all `continuation.resume` calls through `executor.withVirtualMachine` to ensure JSC work happens on the correct thread.

**Affected APIs:**
- `fetch()` — all response handling paths
- `Blob.text()`, `Blob.bytes()`, `Blob.arrayBuffer()`

Each fix is preceded by a test that reproduces the crash.

**Crash:**
```
JSPromiseValue.swift: Fatal error: A JSPromiseValue was constructed on a thread without a current running JSVirtualMachineExecutor.
```